### PR TITLE
Add PR test matrix workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,42 @@
+name: Pull Request Test Matrix
+
+on:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Bootstrap pip
+        run: python -m ensurepip --upgrade
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install package and test dependencies
+        run: python -m pip install -e . build pytest pytest-cov freezegun
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Run test suite
+        run: pytest -q tests

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,15 +13,15 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"


### PR DESCRIPTION
Add .github/workflows/pull-request.yml to run a build-and-test job on pull_request with a Python matrix (3.10–3.13). The workflow checks out the repo, sets up Python and Java (Temurin 17), bootstraps/upgrades pip, installs the package and test dependencies (editable install, build, pytest, pytest-cov, freezegun), builds distributions, and runs the test suite (pytest). fail-fast is disabled so all matrix jobs run.